### PR TITLE
Fix valve profile manual switching

### DIFF
--- a/JS/Classes/Valve.js
+++ b/JS/Classes/Valve.js
@@ -132,7 +132,7 @@ function Valve() {
 		};
 		
 		//if the profile is active, we will set it inactive
-		if (profiles[profile].active){
+		if (profiles[profile.id].active){
 			BrewTroller.communicate(BrewTroller.getAddress() + setProfileStatus + '&' + profiles[profile].bitMask + '&0', callback, profiles);
 		}
 		else{	//else if it is idle we will activate it


### PR DESCRIPTION
When switching valve profiles on/off manually an error was thrown as the wrong property was used to lookup the valve profile. The fixes that error.
